### PR TITLE
Make 'notebook' default for cluster connect

### DIFF
--- a/cloudtools/connect.py
+++ b/cloudtools/connect.py
@@ -7,7 +7,7 @@ def main(main_parser):
 
     parser = argparse.ArgumentParser(parents=[main_parser])
 
-    parser.add_argument('service', type=str, nargs='?', default='spark-ui', choices=['spark-ui', 'spark-ui1', 'spark-ui2', 'spark-history', 'notebook'])
+    parser.add_argument('service', type=str, nargs='?', default='notebook', choices=['spark-ui', 'spark-ui1', 'spark-ui2', 'spark-history', 'notebook'])
     parser.add_argument('--port', '-p', default='10000', type=str, help='Local port to use for SSH tunnel to master node.')
     parser.add_argument('--zone', '-z', default='us-central1-b', type=str, help='Compute zone for Google cluster.')
 


### PR DESCRIPTION
Suggest making `notebook` the default for connecting to the cluster. If the cluster is started with cloudtools defaults there's no spark ui to connect to, so running `connect` with default settings just gives a dead page. Defaulting to `notebook` would also match the default behavior prior to the #21 refactor.