### PR TITLE
Remove sleep

### DIFF
--- a/cloudtools/init_notebook.py
+++ b/cloudtools/init_notebook.py
@@ -163,6 +163,3 @@ if role == 'Master':
     call(['systemctl', 'daemon-reload'])
     call(['systemctl', 'enable', 'jupyter'])
     call(['service', 'jupyter', 'start'])
-
-    # sleep for 30 seconds to allow Jupyter notebook server to start
-    time.sleep(30)


### PR DESCRIPTION
Is the sleep at the end really needed (or at the very least, does it need to be 30 seconds)? In my experience, the service usually starts up pretty quickly (and we have other initialization scripts holding on this that would happily run as soon as it's done - arguably it would be best if they could run in parallel but here we are)