### PR TITLE
Added initialization time-out option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ usage: cluster start [-h] [--hash HASH] [--spark {2.0.2,2.2.0}]
                      [--worker-machine-type WORKER_MACHINE_TYPE] [--zone ZONE]
                      [--properties PROPERTIES] [--metadata METADATA]
                      [--packages PACKAGES] [--jar JAR] [--zip ZIP]
-                     [--init INIT] [--vep] [--dry-run]
+                     [--init INIT] [--init_timeout INIT_TIMEOUT] [--vep] [--dry-run]
                      name
 Start a Dataproc cluster configured for Hail.
 
@@ -214,6 +214,9 @@ optional arguments:
   --jar JAR             Hail jar to use for Jupyter notebook.
   --zip ZIP             Hail zip to use for Jupyter notebook.
   --init INIT           Comma-separated list of init scripts to run.
+  --init_timeout INIT_TIMEOUT
+                        Flag to specify a timeout period for the
+                        initialization action
   --vep                 Configure the cluster to run VEP.
   --dry-run             Print gcloud dataproc command, but don't run it.```
 

--- a/cloudtools/start.py
+++ b/cloudtools/start.py
@@ -77,6 +77,7 @@ def init_parser(parser):
 
     # initialization action flags
     parser.add_argument('--init', default='', help='Comma-separated list of init scripts to run.')
+    parser.add_argument('--init_timeout', default='20m', help='Flag to specify a timeout period for the initialization action')
     parser.add_argument('--vep', action='store_true', help='Configure the cluster to run VEP.')
     parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
@@ -194,6 +195,7 @@ def main(args):
         '--zone={}'.format(args.zone),
         '--properties={}'.format(",".join(properties)),
         '--initialization-actions={}'.format(','.join(init_actions))
+        '--initialization-action-timeout={}'.format(args.init_timeout)
     ]
 
     if args.max_idle:


### PR DESCRIPTION
I found the Dataproc intialization time-out default of 10 minutes to be insufficient in many cases, when I added my own start-up scripts. So I thought it would be useful to be able to control that option from cloudtools.