### PR TITLE
Update start.py

### DIFF
--- a/cloudtools/start.py
+++ b/cloudtools/start.py
@@ -142,9 +142,9 @@ def main(args):
     else:
         hash_length = len(args.hash)
         if hash_length < 12:
-            raise ValueError(f'--hash expects a 12 character git commit hash, received {args.hash}')
+            raise ValueError('--hash expects a 12 character git commit hash, received {}'.format(args.hash))
         elif hash_length > 12:
-            print(f'--hash expects a 12 character git commit hash, I will truncate this longer hash to tweleve characters: {args.hash}')
+            print('--hash expects a 12 character git commit hash, I will truncate this longer hash to tweleve characters: {}'.format(args.hash))
             hash = args.hash[0:12]
         else:
             hash = args.hash

--- a/cloudtools/start.py
+++ b/cloudtools/start.py
@@ -140,7 +140,14 @@ def main(args):
         # Python 3 check_output returns a byte string that needs decoding
         hash = hash.decode() if sys.version_info >= (3, 0) else hash
     else:
-        hash = args.hash
+        hash_length = len(args.hash)
+        if hash_length < 12:
+            raise ValueError(f'--hash expects a 12 character git commit hash, received {args.hash}')
+        elif hash_length > 12:
+            print(f'--hash expects a 12 character git commit hash, I will truncate this longer hash to tweleve characters: {args.hash}')
+            hash = args.hash[0:12]
+        else:
+            hash = args.hash
 
     if not args.config_file:
         args.config_file = 'gs://hail-common/builds/{version}/config/hail-config-{version}-{hash}.json'.format(version=args.version, hash=hash)


### PR DESCRIPTION
Addresses #68 

Error is raised for a too short hash. Warning is issued and hash is truncated for a too long hash.

Longer term solution would be to use a glob expression to search for a matching hash in the bucket.